### PR TITLE
install_all.sh: only do 'npm install' when npm is installed

### DIFF
--- a/install_all.sh
+++ b/install_all.sh
@@ -1,10 +1,24 @@
 #!/usr/bin/env bash
 
 ZIF_BIN="$GOPATH/bin/zifd"
+VERBF=""
 
-go install
-pushd zifd; go install; popd
-pushd ui;  npm install; popd
+if [ "$1" == "-v" ]; then
+    VERBF="-v -x"
+fi
+
+go install $VERB
+
+pushd zifd
+go install $VERB
+popd
+
+which npm >/dev/null 2>&1
+if [ $? -eq 0 ]; then
+    pushd ui
+    npm install
+    popd
+fi
 
 if [ -d "/proc/sys/kernel/pax" ]; then
     paxctl -c "$ZIF_BIN" && setfattr -n user.pax.flags -v "emr" "$ZIF_BIN"


### PR DESCRIPTION
Also added a `-v` flag because building on a rpi is more annoying when no progress is visible.